### PR TITLE
Fix for minor typo in code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This library is collection of utilits for handling those types.
 `tvm_valuetypes.cell` has class `Cell` and functions to work with cells:
 `deserialize_boc`, `cell.serialize_boc`, `cell.serialize_to_object`, `cell.serialize_to_json`, `deserialize_cell_from_json`
 ```
-from tvm_valuertypes.cell import Cell, deserialize_boc
+from tvm_valuetypes.cell import Cell, deserialize_boc
 serialized_cell = bytes.fromhex("B5EE9C72410102010007000102000100024995C5FE15")
 cell1 = deserialize_boc(serialized_c1)
 cell1
@@ -30,8 +30,8 @@ Cell may represent special 'virtual' value type, HashMap, which can be used for 
 `tvm_valuetypes.dict_utils` has special method `parse_hashmap` for dealing with hashmaps. Note the difference between `Hashmap` and `HashmapE`.
 
 ```
-from tvm_valuertypes.cell import Cell
-from tvm_valuertypes.dict_utils import parse_hashmap
+from tvm_valuetypes.cell import Cell
+from tvm_valuetypes.dict_utils import parse_hashmap
 test_dict = bytes.fromhex("B5EE9C7241010A01002D00020120010202014803040003FC0202014805060003F5FE02014807080003DB24020120090900035FF800030020CB8CA892")
 dict_cell = deserialize_boc(test_dict)
 parsed_dict = {}


### PR DESCRIPTION
tvm_valueRtypes => tvm_valuetypes